### PR TITLE
Use C++11 features

### DIFF
--- a/OMakefile
+++ b/OMakefile
@@ -1,3 +1,5 @@
+CXXFLAGS += --std=c++11
+
 section
   CXXFLAGS += -g -O0
   vmount(-l, sample, sample_debug)

--- a/include/sskkm/base.h
+++ b/include/sskkm/base.h
@@ -9,22 +9,22 @@
 
 namespace sskkm {
 
-typedef Eigen::VectorXd DenseVector;
+using DenseVector = Eigen::VectorXd;
 
-typedef Eigen::MatrixXd DenseMatrix;
+using DenseMatrix = Eigen::MatrixXd;
 
-typedef Eigen::SparseVector<double> SparseVector;
+using SparseVector = Eigen::SparseVector<double>;
 
-typedef Eigen::SparseMatrix<double> SparseMatrix;
+using SparseMatrix = Eigen::SparseMatrix<double>;
 
-typedef Eigen::Triplet<double> SparseMatrixCoefficient;
+using SparseMatrixCoefficient = Eigen::Triplet<double>;
 
 /**
    N-size vector where N is the number of nodes. Each element indicates whether
    node having corresponding order belongs to a cluster (value 1.0) or not
    (0.0).
  */
-typedef SparseVector ClusterIndicatorVector;
+using ClusterIndicatorVector = SparseVector;
 
 /**
    N x C matrix where N is the number of nodes and C is the number of clusters.
@@ -32,7 +32,7 @@ typedef SparseVector ClusterIndicatorVector;
    Otherwise 0.0. i.e., the c-th column vector of the matrix is a
    ClusterIndicatorVector for the c-th cluster.
  */
-typedef SparseMatrix ClusterIndicatorMatrix;
+using ClusterIndicatorMatrix = SparseMatrix;
 
 /**
    Reads entire bytes of a stream.

--- a/include/sskkm/base.h
+++ b/include/sskkm/base.h
@@ -37,7 +37,7 @@ typedef SparseMatrix ClusterIndicatorMatrix;
 /**
    Reads entire bytes of a stream.
  */
-inline std::string SlurpStream(std::istream &in) {
+inline std::string SlurpStream(std::istream& in) {
   if (!in.good()) { throw std::invalid_argument("The stream is not readable"); }
   std::ostringstream buf;
   buf << in.rdbuf();

--- a/include/sskkm/base.h
+++ b/include/sskkm/base.h
@@ -34,23 +34,11 @@ typedef SparseVector ClusterIndicatorVector;
  */
 typedef SparseMatrix ClusterIndicatorMatrix;
 
-class InvalidArgument : public std::invalid_argument {
-public:
-  explicit InvalidArgument(const std::string &what_arg)
-      : std::invalid_argument(what_arg) {}
-};
-
-class RuntimeError : public std::runtime_error {
-public:
-  explicit RuntimeError(const std::string &what_arg)
-      : std::runtime_error(what_arg) {}
-};
-
 /**
    Reads entire bytes of a stream.
  */
 inline std::string SlurpStream(std::istream &in) {
-  if (!in.good()) { throw InvalidArgument("The stream is not readable"); }
+  if (!in.good()) { throw std::invalid_argument("The stream is not readable"); }
   std::ostringstream buf;
   buf << in.rdbuf();
   return buf.str();

--- a/include/sskkm/format/base.h
+++ b/include/sskkm/format/base.h
@@ -7,10 +7,10 @@
 
 namespace sskkm {
 
-class InvalidFormat : public InvalidArgument {
+class InvalidFormat : public std::invalid_argument {
  public:
   explicit InvalidFormat(const std::string &what_arg) :
-      InvalidArgument(what_arg) {}
+      std::invalid_argument(what_arg) {}
 };
 
 namespace internal {

--- a/include/sskkm/format/base.h
+++ b/include/sskkm/format/base.h
@@ -9,7 +9,7 @@ namespace sskkm {
 
 class InvalidFormat : public std::invalid_argument {
  public:
-  explicit InvalidFormat(const std::string &what_arg) :
+  explicit InvalidFormat(const std::string& what_arg) :
       std::invalid_argument(what_arg) {}
 };
 

--- a/include/sskkm/format/cluto.h
+++ b/include/sskkm/format/cluto.h
@@ -13,7 +13,7 @@ namespace sskkm {
 
 namespace cluto {
 
-enum MatrixType { kInvalidMatrix, kDenseMatrix, kSparseMatrix };
+enum class MatrixType { InvalidMatrix, DenseMatrix, SparseMatrix };
 
 namespace internal {
 
@@ -170,23 +170,23 @@ inline MatrixType DetermineMatrixType(const std::string& src) {
     try {
       boost::lexical_cast<unsigned>(*iter);
     } catch (const boost::bad_lexical_cast& e) {
-      return kInvalidMatrix;
+      return MatrixType::InvalidMatrix;
     }
     ++num_header_elements;
   }
 
   switch (num_header_elements) {
     case 2:
-      return kDenseMatrix;
+      return MatrixType::DenseMatrix;
     case 3:
-      return kSparseMatrix;
+      return MatrixType::SparseMatrix;
     default:
-      return kInvalidMatrix;
+      return MatrixType::InvalidMatrix;
   }
 }
 
 inline DenseMatrix ParseDenseMatrix(const std::string& src, bool transposed = false) {
-  if (DetermineMatrixType(src) != kDenseMatrix) {
+  if (DetermineMatrixType(src) != MatrixType::DenseMatrix) {
     throw InvalidFormat("Invalid dense matrix foramt");
   }
 
@@ -201,7 +201,7 @@ inline DenseMatrix ParseDenseMatrix(const std::string& src, bool transposed = fa
 }
 
 inline SparseMatrix ParseSparseMatrix(const std::string &src, bool transposed = false) {
-  if (DetermineMatrixType(src) != kSparseMatrix) {
+  if (DetermineMatrixType(src) != MatrixType::SparseMatrix) {
     throw InvalidFormat("Invalid sparse matrix foramt");
   }
 

--- a/include/sskkm/format/cluto.h
+++ b/include/sskkm/format/cluto.h
@@ -22,8 +22,8 @@ namespace internal {
    forward to right next at the end of the header.
 */
 inline void ReadMatrixHeader(
-    boost::tokenizer<>::iterator &iter,
-    const boost::tokenizer<>::iterator &iter_end,
+    boost::tokenizer<>::iterator& iter,
+    const boost::tokenizer<>::iterator& iter_end,
     unsigned *num_rows,
     unsigned *num_cols,
     unsigned *num_nonzeros = 0) {
@@ -46,14 +46,14 @@ inline void ReadMatrixHeader(
       throw InvalidFormat("Header includes not expected properties");
     }
     ++iter;
-  } catch (const boost::bad_lexical_cast &e) {
+  } catch (const boost::bad_lexical_cast& e) {
     throw InvalidFormat("Not looks like a integer");
   }
 }
 
 inline DenseMatrix ReadDenseMatrix(
-    boost::tokenizer<>::iterator &iter,
-    const boost::tokenizer<>::iterator &iter_end,
+    boost::tokenizer<>::iterator& iter,
+    const boost::tokenizer<>::iterator& iter_end,
     unsigned num_rows,
     unsigned num_cols,
     bool transposed) {
@@ -71,7 +71,7 @@ inline DenseMatrix ReadDenseMatrix(
         } else {
           matrix(i, j) = boost::lexical_cast<double>(*iter);
         }
-      } catch (const boost::bad_lexical_cast &e) {
+      } catch (const boost::bad_lexical_cast& e) {
         throw InvalidFormat(
             "Coefficient does not look a like real number");
       }
@@ -91,8 +91,8 @@ inline DenseMatrix ReadDenseMatrix(
 }
 
 inline SparseMatrix ReadSparseMatrix(
-    boost::tokenizer<>::iterator &iter,
-    const boost::tokenizer<>::iterator &iter_end,
+    boost::tokenizer<>::iterator& iter,
+    const boost::tokenizer<>::iterator& iter_end,
     unsigned num_rows,
     unsigned num_cols,
     unsigned num_nonzeros,
@@ -117,7 +117,7 @@ inline SparseMatrix ReadSparseMatrix(
         ++iter;
         value = boost::lexical_cast<double>(*iter);
         ++iter;
-      } catch (const boost::bad_lexical_cast &e) {
+      } catch (const boost::bad_lexical_cast& e) {
         throw InvalidFormat(
             transposed ?
             "Row index or coefficient value do not look like a number" :
@@ -161,7 +161,7 @@ inline SparseMatrix ReadSparseMatrix(
 
 }  // namespace internal
 
-inline MatrixType DetermineMatrixType(const std::string &src) {
+inline MatrixType DetermineMatrixType(const std::string& src) {
   boost::tokenizer<> tokenizer(src, ::sskkm::internal::separator_);
   unsigned num_header_elements = 0;
   for (boost::tokenizer<>::iterator iter = tokenizer.begin();
@@ -169,7 +169,7 @@ inline MatrixType DetermineMatrixType(const std::string &src) {
        ++iter) {
     try {
       boost::lexical_cast<unsigned>(*iter);
-    } catch (const boost::bad_lexical_cast &e) {
+    } catch (const boost::bad_lexical_cast& e) {
       return kInvalidMatrix;
     }
     ++num_header_elements;
@@ -185,7 +185,7 @@ inline MatrixType DetermineMatrixType(const std::string &src) {
   }
 }
 
-inline DenseMatrix ParseDenseMatrix(const std::string &src, bool transposed = false) {
+inline DenseMatrix ParseDenseMatrix(const std::string& src, bool transposed = false) {
   if (DetermineMatrixType(src) != kDenseMatrix) {
     throw InvalidFormat("Invalid dense matrix foramt");
   }

--- a/include/sskkm/format/graphviz.h
+++ b/include/sskkm/format/graphviz.h
@@ -1,9 +1,9 @@
 #ifndef SSKKM_FORMAT_GRAPHVIZ_H_
 #define SSKKM_FORMAT_GRAPHVIZ_H_
 
-#include <boost/foreach.hpp>
 #include <boost/graph/graphviz.hpp>
 #include <boost/property_map/dynamic_property_map.hpp>
+#include <tuple>
 
 #include "sskkm/ss_kernel_k_means.h"
 
@@ -15,11 +15,12 @@ namespace internal {
 
 inline void SetDefaultEdgeWeight(
     UndirectedGraph *graph, double default_weight) {
-  BOOST_FOREACH (
-      const boost::graph_traits<UndirectedGraph>::edge_descriptor edge,
-      boost::edges(*graph)) {
-    if (boost::get(boost::edge_weight, *graph, edge) == 0.0) {
-      boost::put(boost::edge_weight, *graph, edge, default_weight);
+  boost::graph_traits<UndirectedGraph>::edge_iterator iter, iter_end;
+  for (std::tie(iter, iter_end) = boost::edges(*graph);
+       iter != iter_end;
+       ++iter) {
+    if (boost::get(boost::edge_weight, *graph, *iter) == 0.0) {
+      boost::put(boost::edge_weight, *graph, *iter, default_weight);
     }
   }
 }

--- a/include/sskkm/format/graphviz.h
+++ b/include/sskkm/format/graphviz.h
@@ -27,7 +27,7 @@ inline void SetDefaultEdgeWeight(
 }  // namespace internal
 
 inline UndirectedGraph ReadUndirectedGraph(
-    const std::string &source,
+    const std::string& source,
     double default_edge_weight) {
   UndirectedGraph graph;
   boost::dynamic_properties properties;

--- a/include/sskkm/kernel_k_means.h
+++ b/include/sskkm/kernel_k_means.h
@@ -45,8 +45,8 @@ namespace internal {
   distances between a vector and each cluster centroid.
 */
 inline NormMatrix ComputeNormMatrix(
-    const ClusterIndicatorMatrix &clusters,
-    const KernelMatrix &kernels) {
+    const ClusterIndicatorMatrix& clusters,
+    const KernelMatrix& kernels) {
   // Each element is the number of vectors in corresponding cluster.
   Eigen::ArrayXd cluster_sizes(clusters.cols());
   for (ClusterIndicatorMatrix::Index i = 0; i < clusters.cols(); ++i) {
@@ -90,9 +90,9 @@ inline NormMatrix ComputeNormMatrix(
    1st term as well as the unweighted version.
 */
 inline NormMatrix ComputeWeightedNormMatrix(
-    const ClusterIndicatorMatrix &clusters,
-    const KernelMatrix &kernels,
-    const WeightVector &weights) {
+    const ClusterIndicatorMatrix& clusters,
+    const KernelMatrix& kernels,
+    const WeightVector& weights) {
   DenseVector cluster_total_weights = clusters.transpose() * weights;
 
   DenseMatrix kc = kernels.cwiseProduct(
@@ -114,11 +114,11 @@ inline NormMatrix ComputeWeightedNormMatrix(
 }
 
 inline NormMatrix ComputeWeightedNormMatrix(
-    const ClusterIndicatorMatrix &clusters,
-    const KernelMatrix &kernels,
-    const KernelMatrix &weighted_kernels,
-    const KernelMatrix &weighted_weighted_kernels,
-    const WeightVector &weights) {
+    const ClusterIndicatorMatrix& clusters,
+    const KernelMatrix& kernels,
+    const KernelMatrix& weighted_kernels,
+    const KernelMatrix& weighted_weighted_kernels,
+    const WeightVector& weights) {
   DenseVector cluster_total_weights = clusters.transpose() * weights;
 
   DenseMatrix term2s = -2 * (weighted_kernels * clusters).cwiseQuotient(
@@ -137,7 +137,7 @@ inline NormMatrix ComputeWeightedNormMatrix(
    decrease.
  */
 inline ClusterIndicatorMatrix ComputeClusterIndicatorMatrix(
-    const NormMatrix &norms) {
+    const NormMatrix& norms) {
   std::vector<SparseMatrixCoefficient> triplets;
   for (NormMatrix::Index i = 0; i < norms.rows(); ++i) {
     NormMatrix::Index cluster_index;
@@ -164,8 +164,8 @@ inline ClusterIndicatorMatrix ComputeClusterIndicatorMatrix(
 }
 
 inline void ComputeWeightedKernelMatrix(
-    const KernelMatrix &kernels,
-    const WeightVector &weights,
+    const KernelMatrix& kernels,
+    const WeightVector& weights,
     KernelMatrix *weighted_kernels,
     KernelMatrix *weighted_weighted_kernels) {
   weighted_kernels->rowwise() = weights.transpose();
@@ -178,16 +178,16 @@ inline void ComputeWeightedKernelMatrix(
 
 class TooFewClustersLeft : public std::runtime_error {
  public:
-  explicit TooFewClustersLeft(const std::string &what_arg)
+  explicit TooFewClustersLeft(const std::string& what_arg)
       : std::runtime_error(what_arg) {}
 };
 
 template <typename ConvergencePredicator>
 inline ClusterIndicatorMatrix ExecuteKernelKMeans(
-    const ClusterIndicatorMatrix &initial_clusters,
+    const ClusterIndicatorMatrix& initial_clusters,
     int k_min,
-    const KernelMatrix &kernels,
-    ConvergencePredicator &converged) {
+    const KernelMatrix& kernels,
+    ConvergencePredicator& converged) {
   if (kernels.rows() != kernels.cols()) {
     throw std::invalid_argument("Kernel matrix must be a square matrix");
   }
@@ -214,11 +214,11 @@ inline ClusterIndicatorMatrix ExecuteKernelKMeans(
 
 template <typename ConvergencePredicator>
 inline ClusterIndicatorMatrix ExecuteWeightedKernelKMeans(
-    const ClusterIndicatorMatrix &initial_clusters,
+    const ClusterIndicatorMatrix& initial_clusters,
     int k_min,
-    const KernelMatrix &kernels,
-    const WeightVector &weights,
-    ConvergencePredicator &converged,
+    const KernelMatrix& kernels,
+    const WeightVector& weights,
+    ConvergencePredicator& converged,
     bool less_memory = false) {
   if (kernels.rows() != kernels.cols()) {
     throw std::invalid_argument("Kernel matrix must be a square matrix");

--- a/include/sskkm/kernel_k_means.h
+++ b/include/sskkm/kernel_k_means.h
@@ -176,10 +176,10 @@ inline void ComputeWeightedKernelMatrix(
 
 }  // namespace internal
 
-class TooFewClustersLeft : public RuntimeError {
+class TooFewClustersLeft : public std::runtime_error {
  public:
   explicit TooFewClustersLeft(const std::string &what_arg)
-      : RuntimeError(what_arg) {}
+      : std::runtime_error(what_arg) {}
 };
 
 template <typename ConvergencePredicator>
@@ -189,10 +189,10 @@ inline ClusterIndicatorMatrix ExecuteKernelKMeans(
     const KernelMatrix &kernels,
     ConvergencePredicator &converged) {
   if (kernels.rows() != kernels.cols()) {
-    throw InvalidArgument("Kernel matrix must be a square matrix");
+    throw std::invalid_argument("Kernel matrix must be a square matrix");
   }
   if (initial_clusters.rows() != kernels.rows()) {
-    throw InvalidArgument(
+    throw std::invalid_argument(
         "Cluster indicator matrix doesn't match for kernel matrix in size");
   }
 
@@ -221,14 +221,14 @@ inline ClusterIndicatorMatrix ExecuteWeightedKernelKMeans(
     ConvergencePredicator &converged,
     bool less_memory = false) {
   if (kernels.rows() != kernels.cols()) {
-    throw InvalidArgument("Kernel matrix must be a square matrix");
+    throw std::invalid_argument("Kernel matrix must be a square matrix");
   }
   if (initial_clusters.rows() != kernels.rows()) {
-    throw InvalidArgument(
+    throw std::invalid_argument(
         "Cluster indicator matrix doesn't match for kernel matrix in size");
   }
   if (weights.size() != initial_clusters.rows()) {
-    throw InvalidArgument("Not enough or too many weights");
+    throw std::invalid_argument("Not enough or too many weights");
   }
 
   ClusterIndicatorMatrix clusters = initial_clusters;

--- a/include/sskkm/kernel_k_means.h
+++ b/include/sskkm/kernel_k_means.h
@@ -13,20 +13,20 @@ namespace sskkm {
    K(nv, mv) where K is the kernel function, and nv, mv are the n-th and m-th 
    vectors respectively.
  */
-typedef DenseMatrix KernelMatrix;
+using KernelMatrix = DenseMatrix;
 
 /**
    N x C matrix where N is the number of vectors and C is the number of 
    clusters. The element at (n, c) is the distance between the n-th vector and 
    centroid of the c-th cluster in a kernel space.
  */
-typedef DenseMatrix NormMatrix;
+using NormMatrix = DenseMatrix;
 
 /**
    N-length vector where N is the number of vectors. Each scalar represents the 
    weight of corresponding vectors.
  */
-typedef DenseVector WeightVector;
+using WeightVector = DenseVector;
 
 namespace internal {
 

--- a/include/sskkm/kernel_k_means.h
+++ b/include/sskkm/kernel_k_means.h
@@ -183,7 +183,7 @@ class TooFewClustersLeft : public std::runtime_error {
 };
 
 template <typename ConvergencePredicator>
-inline ClusterIndicatorMatrix ExecuteKernelKMeans(
+ClusterIndicatorMatrix ExecuteKernelKMeans(
     const ClusterIndicatorMatrix& initial_clusters,
     int k_min,
     const KernelMatrix& kernels,
@@ -213,7 +213,7 @@ inline ClusterIndicatorMatrix ExecuteKernelKMeans(
 }
 
 template <typename ConvergencePredicator>
-inline ClusterIndicatorMatrix ExecuteWeightedKernelKMeans(
+ClusterIndicatorMatrix ExecuteWeightedKernelKMeans(
     const ClusterIndicatorMatrix& initial_clusters,
     int k_min,
     const KernelMatrix& kernels,

--- a/include/sskkm/kernel_matrix.h
+++ b/include/sskkm/kernel_matrix.h
@@ -10,20 +10,20 @@
 namespace sskkm {
 
 inline KernelMatrix ComputePolynomialKernelMatrix(
-    const DenseMatrix &vectors, double linear_shift, double exponent) {
+    const DenseMatrix& vectors, double linear_shift, double exponent) {
   return KernelMatrix(
       ((vectors.transpose() * vectors).array() + linear_shift).pow(exponent));
 }
 
 inline KernelMatrix ComputePolynomialKernelMatrix(
-    const SparseMatrix &vectors, double linear_shift, double exponent) {
+    const SparseMatrix& vectors, double linear_shift, double exponent) {
   DenseMatrix products = (vectors.transpose() * vectors).eval();
   return KernelMatrix((products.array() + linear_shift).pow(exponent));
 }
 
 template <typename Matrix>
 inline KernelMatrix ComputeGaussianKernelMatrix(
-    const Matrix &vectors, double deviation) {
+    const Matrix& vectors, double deviation) {
   DenseMatrix products = (vectors.transpose() * vectors).eval();
   KernelMatrix exponents =
       (products.diagonal().replicate(1, vectors.cols()) +

--- a/include/sskkm/kernel_matrix.h
+++ b/include/sskkm/kernel_matrix.h
@@ -22,7 +22,7 @@ inline KernelMatrix ComputePolynomialKernelMatrix(
 }
 
 template <typename Matrix>
-inline KernelMatrix ComputeGaussianKernelMatrix(
+KernelMatrix ComputeGaussianKernelMatrix(
     const Matrix& vectors, double deviation) {
   DenseMatrix products = (vectors.transpose() * vectors).eval();
   KernelMatrix exponents =

--- a/include/sskkm/ss_kernel_k_means.h
+++ b/include/sskkm/ss_kernel_k_means.h
@@ -57,7 +57,11 @@ using MustLinks = UndirectedGraph;
 
 using CannotLinks = UndirectedGraph;
 
-enum ClusteringObjective { kRatioCut, kRatioAssociation, kNormalizedCut };
+enum class ClusteringObjective {
+  NormalizedCut,
+  RatioAssociation,
+  RatioCut,
+};
 
 namespace internal {
 
@@ -415,7 +419,7 @@ inline ClusterIndicatorMatrix ExecuteSSKernelKMeans(
     double diagonal_shift = 0.0,
     bool less_memory = false) {
   switch (objective) {
-    case kNormalizedCut: {
+    case ClusteringObjective::NormalizedCut: {
       WeightVector degrees = internal::ComputeVertexDegreeVector(graph);
       KernelMatrix kernels =
           internal::ComputeNormalizedCutKernelMatirx(
@@ -426,7 +430,7 @@ inline ClusterIndicatorMatrix ExecuteSSKernelKMeans(
       return ExecuteWeightedKernelKMeans(
           clusters, k_min, kernels, degrees, converged, less_memory);
     }
-    case kRatioAssociation: {
+    case ClusteringObjective::RatioAssociation: {
       KernelMatrix kernels =
           internal::ComputeRatioAssociationKernelMatirx(
               graph, must_links, cannot_links, diagonal_shift);
@@ -435,16 +439,13 @@ inline ClusterIndicatorMatrix ExecuteSSKernelKMeans(
               k, kernels, must_links, cannot_links);
       return ExecuteKernelKMeans(clusters, k_min, kernels, converged);
     }
-    case kRatioCut: {
+    case ClusteringObjective::RatioCut: {
       KernelMatrix kernels =
           internal::ComputeRatioCutKernelMatrix(
               graph, must_links, cannot_links, diagonal_shift);
       ClusterIndicatorMatrix clusters = internal::InitializeFarthestFirst(
               k, kernels, must_links, cannot_links);
       return ExecuteKernelKMeans(clusters, k_min, kernels, converged);
-    }
-    default: {
-      throw std::invalid_argument("Unknown clustering objective.");
     }
   }
 }

--- a/include/sskkm/ss_kernel_k_means.h
+++ b/include/sskkm/ss_kernel_k_means.h
@@ -59,10 +59,10 @@ typedef UndirectedGraph CannotLinks;
 
 enum ClusteringObjective { kRatioCut, kRatioAssociation, kNormalizedCut };
 
-class InconsistentConstraints : public RuntimeError {
+class InconsistentConstraints : public std::runtime_error {
  public:
   explicit InconsistentConstraints(const std::string &what_arg)
-      : RuntimeError(what_arg) {}
+      : std::runtime_error(what_arg) {}
 };
 
 namespace internal {
@@ -193,7 +193,7 @@ inline ConstraintPenaltyMatrix ComputeConstraintPenaltyMatrix(
     const MustLinks &must_links,
     const CannotLinks &cannot_links) {
   if (boost::num_vertices(must_links) != boost::num_vertices(cannot_links)) {
-    throw InvalidArgument(
+    throw std::invalid_argument(
         "The numbers of vertices in must-links and cannot-links must be"
         " equal.");
   }
@@ -347,7 +347,7 @@ inline ClusterIndicatorMatrix InitializeFarthestFirst(
     std::ostringstream message;
     message << "Failed to cluster initialize: Cannot set up " << k
             << " cluster(s) such that satisfies given constraints.";
-    throw RuntimeError(message.str());
+    throw std::runtime_error(message.str());
   }
 
   // Finds the largest component from candidate components.
@@ -450,7 +450,7 @@ inline ClusterIndicatorMatrix ExecuteSSKernelKMeans(
       return ExecuteKernelKMeans(clusters, k_min, kernels, converged);
     }
     default: {
-      throw InvalidArgument("Unknown clustering objective.");
+      throw std::invalid_argument("Unknown clustering objective.");
     }
   }
 }

--- a/include/sskkm/ss_kernel_k_means.h
+++ b/include/sskkm/ss_kernel_k_means.h
@@ -408,7 +408,7 @@ inline ClusterIndicatorMatrix InitializeFarthestFirst(
 }  // namespace internal
 
 template <typename ConvergencePredicator>
-inline ClusterIndicatorMatrix ExecuteSSKernelKMeans(
+ClusterIndicatorMatrix ExecuteSSKernelKMeans(
     int k,
     int k_min,
     ClusteringObjective objective,

--- a/include/sskkm/ss_kernel_k_means.h
+++ b/include/sskkm/ss_kernel_k_means.h
@@ -80,9 +80,9 @@ inline ComponentIndicatorMatrix ComputeComponentIndicatorMatrix(
   ComponentIndex max_component_index = 0;
   std::vector<SparseMatrixCoefficient> component_indicator_coeffs;
   component_indicator_coeffs.reserve(components.size());
-  ComponentIndices::key_type vertex;
-  ComponentIndices::mapped_type component;
-  BOOST_FOREACH (boost::tie(vertex, component), components) {
+  for (const auto &vertex_component_pair: components) {
+    const auto vertex = vertex_component_pair.first;
+    const auto component = vertex_component_pair.second;
     if (max_component_index < component) { max_component_index = component; }
     component_indicator_coeffs.push_back(
         SparseMatrixCoefficient(vertex, component, 1.0));
@@ -135,9 +135,9 @@ inline CannotLinks ComputeTransitiveCannotLinks(
       cannot_link_component_pairs.begin(), cannot_link_component_pairs.end());
 
   UndirectedGraph cannot_links(boost::num_vertices(given_cannot_links));
-  ComponentIndex component1, component2;
-  BOOST_FOREACH (
-      boost::tie(component1, component2), cannot_link_component_pairs) {
+  for (const auto &cannot_link_component_pair: cannot_link_component_pairs) {
+    const auto component1 = cannot_link_component_pair.first;
+    const auto component2 = cannot_link_component_pair.second;
     for (ComponentIndicatorMatrix::InnerIterator iter1(components, component1);
          iter1;
          ++iter1) {
@@ -375,8 +375,7 @@ inline ClusterIndicatorMatrix InitializeFarthestFirst(
          ++i) {
       if (is_chosen_component[i]) { continue; }
       double similarity = 0.0;
-      BOOST_FOREACH (
-          const ComponentIndicatorMatrix::Index j, chosen_component_indices) {
+      for (const auto j: chosen_component_indices) {
         similarity += component_component_similarities(i, j);
       }
       if (similarity < worst_similarity) {

--- a/include/sskkm/ss_kernel_k_means.h
+++ b/include/sskkm/ss_kernel_k_means.h
@@ -59,12 +59,6 @@ typedef UndirectedGraph CannotLinks;
 
 enum ClusteringObjective { kRatioCut, kRatioAssociation, kNormalizedCut };
 
-class InconsistentConstraints : public std::runtime_error {
- public:
-  explicit InconsistentConstraints(const std::string& what_arg)
-      : std::runtime_error(what_arg) {}
-};
-
 namespace internal {
 
 typedef boost::graph_traits<UndirectedGraph>::vertices_size_type ComponentIndex;

--- a/include/sskkm/ss_kernel_k_means.h
+++ b/include/sskkm/ss_kernel_k_means.h
@@ -24,50 +24,50 @@ namespace sskkm {
 
 namespace internal {
 
-typedef std::size_t VertexIndex;
+using VertexIndex = std::size_t;
 
-typedef boost::property<
+using VertexProperty = boost::property<
   boost::vertex_name_t,
   std::string,
-  boost::property<boost::vertex_index_t, VertexIndex> > VertexProperty;
+  boost::property<boost::vertex_index_t, VertexIndex>>;
 
-typedef boost::property<boost::edge_weight_t, double> EdgeProperty;
+using EdgeProperty = boost::property<boost::edge_weight_t, double>;
 
-typedef SparseMatrix AdjacencyMatrix;  // aka. Similarity matrix.
+using AdjacencyMatrix = SparseMatrix;  // aka. Similarity matrix.
 
-typedef SparseMatrix ConstraintPenaltyMatrix;
+using ConstraintPenaltyMatrix = SparseMatrix;
 
-typedef boost::adjacency_list<
+using DirectedGraph = boost::adjacency_list<
   boost::hash_setS,
   boost::vecS,
   boost::directedS,
   internal::VertexProperty,
-  internal::EdgeProperty> DirectedGraph;
+  internal::EdgeProperty>;
 
 }  // namespace internal
 
-typedef boost::adjacency_list<
+using UndirectedGraph = boost::adjacency_list<
   boost::hash_setS,
   boost::vecS,
   boost::undirectedS,
   internal::VertexProperty,
-  internal::EdgeProperty> UndirectedGraph;
+  internal::EdgeProperty>;
 
-typedef UndirectedGraph MustLinks;
+using MustLinks = UndirectedGraph;
 
-typedef UndirectedGraph CannotLinks;
+using CannotLinks = UndirectedGraph;
 
 enum ClusteringObjective { kRatioCut, kRatioAssociation, kNormalizedCut };
 
 namespace internal {
 
-typedef boost::graph_traits<UndirectedGraph>::vertices_size_type ComponentIndex;
+using ComponentIndex = boost::graph_traits<UndirectedGraph>::vertices_size_type;
 
-typedef std::map<
+using ComponentIndices = std::map<
   boost::graph_traits<UndirectedGraph>::vertex_descriptor,
-  ComponentIndex> ComponentIndices;
+  ComponentIndex>;
 
-typedef SparseMatrix ComponentIndicatorMatrix;
+using ComponentIndicatorMatrix = SparseMatrix;
 
 inline ComponentIndicatorMatrix ComputeComponentIndicatorMatrix(
     const ComponentIndices& components) {

--- a/include/sskkm/ss_kernel_k_means.h
+++ b/include/sskkm/ss_kernel_k_means.h
@@ -61,7 +61,7 @@ enum ClusteringObjective { kRatioCut, kRatioAssociation, kNormalizedCut };
 
 class InconsistentConstraints : public std::runtime_error {
  public:
-  explicit InconsistentConstraints(const std::string &what_arg)
+  explicit InconsistentConstraints(const std::string& what_arg)
       : std::runtime_error(what_arg) {}
 };
 
@@ -76,11 +76,11 @@ typedef std::map<
 typedef SparseMatrix ComponentIndicatorMatrix;
 
 inline ComponentIndicatorMatrix ComputeComponentIndicatorMatrix(
-    const ComponentIndices &components) {
+    const ComponentIndices& components) {
   ComponentIndex max_component_index = 0;
   std::vector<SparseMatrixCoefficient> component_indicator_coeffs;
   component_indicator_coeffs.reserve(components.size());
-  for (const auto &vertex_component_pair: components) {
+  for (const auto& vertex_component_pair: components) {
     const auto vertex = vertex_component_pair.first;
     const auto component = vertex_component_pair.second;
     if (max_component_index < component) { max_component_index = component; }
@@ -94,7 +94,7 @@ inline ComponentIndicatorMatrix ComputeComponentIndicatorMatrix(
   return component_indicator;
 }
 
-inline DirectedGraph Undirected2Directed(const UndirectedGraph &undirected) {
+inline DirectedGraph Undirected2Directed(const UndirectedGraph& undirected) {
   DirectedGraph directed;
   boost::copy_graph(undirected, directed);
   BOOST_FOREACH (
@@ -109,9 +109,9 @@ inline DirectedGraph Undirected2Directed(const UndirectedGraph &undirected) {
 }
 
 inline CannotLinks ComputeTransitiveCannotLinks(
-    const CannotLinks &given_cannot_links,
-    const ComponentIndices &component_indices,
-    const ComponentIndicatorMatrix &components) {
+    const CannotLinks& given_cannot_links,
+    const ComponentIndices& component_indices,
+    const ComponentIndicatorMatrix& components) {
   // Lists up component pairs in which there is at least one cannot link across
   // them.
   std::vector<
@@ -135,7 +135,7 @@ inline CannotLinks ComputeTransitiveCannotLinks(
       cannot_link_component_pairs.begin(), cannot_link_component_pairs.end());
 
   UndirectedGraph cannot_links(boost::num_vertices(given_cannot_links));
-  for (const auto &cannot_link_component_pair: cannot_link_component_pairs) {
+  for (const auto& cannot_link_component_pair: cannot_link_component_pairs) {
     const auto component1 = cannot_link_component_pair.first;
     const auto component2 = cannot_link_component_pair.second;
     for (ComponentIndicatorMatrix::InnerIterator iter1(components, component1);
@@ -157,7 +157,7 @@ inline CannotLinks ComputeTransitiveCannotLinks(
 }
 
 inline UndirectedGraph ComputeTransitiveMustLinks(
-    const UndirectedGraph &given_must_links) {
+    const UndirectedGraph& given_must_links) {
   DirectedGraph inferred_must_links;
   boost::transitive_closure(
       Undirected2Directed(given_must_links), inferred_must_links);
@@ -166,7 +166,7 @@ inline UndirectedGraph ComputeTransitiveMustLinks(
   return must_links;
 }
 
-inline AdjacencyMatrix ComputeAdjacencyMatrix(const UndirectedGraph &graph) {
+inline AdjacencyMatrix ComputeAdjacencyMatrix(const UndirectedGraph& graph) {
   std::vector<SparseMatrixCoefficient> coeffs;
   coeffs.reserve(2 * boost::num_edges(graph));
   BOOST_FOREACH (
@@ -190,8 +190,8 @@ inline AdjacencyMatrix ComputeAdjacencyMatrix(const UndirectedGraph &graph) {
 }
 
 inline ConstraintPenaltyMatrix ComputeConstraintPenaltyMatrix(
-    const MustLinks &must_links,
-    const CannotLinks &cannot_links) {
+    const MustLinks& must_links,
+    const CannotLinks& cannot_links) {
   if (boost::num_vertices(must_links) != boost::num_vertices(cannot_links)) {
     throw std::invalid_argument(
         "The numbers of vertices in must-links and cannot-links must be"
@@ -201,8 +201,8 @@ inline ConstraintPenaltyMatrix ComputeConstraintPenaltyMatrix(
   std::vector<SparseMatrixCoefficient> coeffs;
   coeffs.reserve(boost::num_edges(must_links) + boost::num_edges(cannot_links));
 
-  const boost::property_map<MustLinks, boost::vertex_index_t>::const_type
-      &vertex_indices = boost::get(boost::vertex_index, must_links);
+  const boost::property_map<MustLinks, boost::vertex_index_t>::const_type&
+      vertex_indices = boost::get(boost::vertex_index, must_links);
 
   BOOST_FOREACH (
       const boost::graph_traits<MustLinks>::edge_descriptor edge,
@@ -240,7 +240,7 @@ inline ConstraintPenaltyMatrix ComputeConstraintPenaltyMatrix(
   return penalty_matrix;
 }
 
-inline DenseVector ComputeVertexDegreeVector(const UndirectedGraph &graph) {
+inline DenseVector ComputeVertexDegreeVector(const UndirectedGraph& graph) {
   DenseVector degrees = DenseVector::Zero(boost::num_vertices(graph));
   BOOST_FOREACH (
       const boost::graph_traits<UndirectedGraph>::vertex_descriptor vertex,
@@ -252,10 +252,10 @@ inline DenseVector ComputeVertexDegreeVector(const UndirectedGraph &graph) {
 }
 
 inline KernelMatrix ComputeNormalizedCutKernelMatirx(
-    const UndirectedGraph &graph,
-    const MustLinks &must_links,
-    const CannotLinks &cannot_links,
-    const WeightVector &degrees,
+    const UndirectedGraph& graph,
+    const MustLinks& must_links,
+    const CannotLinks& cannot_links,
+    const WeightVector& degrees,
     double diagonal_shift) {
   DenseMatrix inversed_degrees = degrees.cwiseInverse().asDiagonal();
   KernelMatrix kernel = inversed_degrees *
@@ -267,9 +267,9 @@ inline KernelMatrix ComputeNormalizedCutKernelMatirx(
 }
 
 inline KernelMatrix ComputeRatioAssociationKernelMatirx(
-    const UndirectedGraph &graph,
-    const MustLinks &must_links,
-    const CannotLinks &cannot_links,
+    const UndirectedGraph& graph,
+    const MustLinks& must_links,
+    const CannotLinks& cannot_links,
     double diagonal_shift) {
   KernelMatrix kernel = ComputeAdjacencyMatrix(graph) +
       ComputeConstraintPenaltyMatrix(must_links, cannot_links);
@@ -281,9 +281,9 @@ inline KernelMatrix ComputeRatioAssociationKernelMatirx(
 }
 
 inline KernelMatrix ComputeRatioCutKernelMatrix(
-    const UndirectedGraph &graph,
-    const MustLinks &must_links,
-    const CannotLinks &cannot_links,
+    const UndirectedGraph& graph,
+    const MustLinks& must_links,
+    const CannotLinks& cannot_links,
     double diagonal_shift) {
   KernelMatrix kernel =
       (ComputeAdjacencyMatrix(graph) +
@@ -297,12 +297,12 @@ inline KernelMatrix ComputeRatioCutKernelMatrix(
 }
 
 inline ComponentIndicatorMatrix ComputeCannotLinkedComponents(
-    const ComponentIndices &component_indices,
-    const ComponentIndicatorMatrix &components,
-    const CannotLinks &cannot_links) {
+    const ComponentIndices& component_indices,
+    const ComponentIndicatorMatrix& components,
+    const CannotLinks& cannot_links) {
   std::vector<bool> is_cannot_linked_component(components.cols());
   BOOST_FOREACH (
-      const boost::graph_traits<CannotLinks>::vertex_descriptor &vertex,
+      const boost::graph_traits<CannotLinks>::vertex_descriptor& vertex,
       boost::vertices(cannot_links)) {
     ComponentIndex component = component_indices.find(vertex)->second;
     is_cannot_linked_component[component] = true;
@@ -326,9 +326,9 @@ inline ComponentIndicatorMatrix ComputeCannotLinkedComponents(
 
 inline ClusterIndicatorMatrix InitializeFarthestFirst(
     std::size_t k,
-    const KernelMatrix &kernels,
-    const MustLinks &must_links,
-    const CannotLinks &cannot_links) {
+    const KernelMatrix& kernels,
+    const MustLinks& must_links,
+    const CannotLinks& cannot_links) {
   MustLinks inferred_must_links = ComputeTransitiveMustLinks(must_links);
   ComponentIndices component_indices;
   boost::connected_components(
@@ -414,10 +414,10 @@ inline ClusterIndicatorMatrix ExecuteSSKernelKMeans(
     int k,
     int k_min,
     ClusteringObjective objective,
-    const UndirectedGraph &graph,
-    const MustLinks &must_links,
-    const CannotLinks &cannot_links,
-    ConvergencePredicator &converged,
+    const UndirectedGraph& graph,
+    const MustLinks& must_links,
+    const CannotLinks& cannot_links,
+    ConvergencePredicator& converged,
     double diagonal_shift = 0.0,
     bool less_memory = false) {
   switch (objective) {

--- a/include/sskkm/ss_kernel_k_means.h
+++ b/include/sskkm/ss_kernel_k_means.h
@@ -15,6 +15,7 @@
 #include <boost/property_map/property_map.hpp>
 #include <limits>
 #include <sstream>
+#include <tuple>
 #include <vector>
 
 #include "sskkm/base.h"
@@ -78,9 +79,10 @@ inline ComponentIndicatorMatrix ComputeComponentIndicatorMatrix(
   ComponentIndex max_component_index = 0;
   std::vector<SparseMatrixCoefficient> component_indicator_coeffs;
   component_indicator_coeffs.reserve(components.size());
-  for (const auto& vertex_component_pair: components) {
-    const auto vertex = vertex_component_pair.first;
-    const auto component = vertex_component_pair.second;
+  for (const auto& vertex_component_pair : components) {
+      ComponentIndices::key_type vertex;
+      ComponentIndices::mapped_type component;
+      std::tie(vertex, component) = vertex_component_pair;
     if (max_component_index < component) { max_component_index = component; }
     component_indicator_coeffs.push_back(
         SparseMatrixCoefficient(vertex, component, 1.0));
@@ -133,9 +135,9 @@ inline CannotLinks ComputeTransitiveCannotLinks(
       cannot_link_component_pairs.begin(), cannot_link_component_pairs.end());
 
   UndirectedGraph cannot_links(boost::num_vertices(given_cannot_links));
-  for (const auto& cannot_link_component_pair: cannot_link_component_pairs) {
-    const auto component1 = cannot_link_component_pair.first;
-    const auto component2 = cannot_link_component_pair.second;
+  for (const auto& cannot_link_component_pair : cannot_link_component_pairs) {
+    ComponentIndex component1, component2;
+    std::tie(component1, component2) = cannot_link_component_pair;
     for (ComponentIndicatorMatrix::InnerIterator iter1(components, component1);
          iter1;
          ++iter1) {
@@ -373,7 +375,7 @@ inline ClusterIndicatorMatrix InitializeFarthestFirst(
          ++i) {
       if (is_chosen_component[i]) { continue; }
       double similarity = 0.0;
-      for (const auto j: chosen_component_indices) {
+      for (const auto j : chosen_component_indices) {
         similarity += component_component_similarities(i, j);
       }
       if (similarity < worst_similarity) {

--- a/sample/graph_clustering.cc
+++ b/sample/graph_clustering.cc
@@ -1,4 +1,3 @@
-#include <boost/foreach.hpp>
 /*
   This header is not used directly in this source file but
   |sskkm/ss_kernel_k_means.h|, a header included below, does. And it seems that
@@ -159,8 +158,7 @@ int main(int argc, const char **argv) {
         cluster_numbers[iter.row()] = iter.col();
       }
     }
-    BOOST_FOREACH (
-        const ClusterIndicatorMatrix::Index cluster_id, cluster_numbers) {
+    for (const auto cluster_id: cluster_numbers) {
       std::cout << cluster_id << std::endl;
     }
   } catch (const std::exception &e) {

--- a/sample/graph_clustering.cc
+++ b/sample/graph_clustering.cc
@@ -29,13 +29,13 @@ namespace {
 
 void ExitWithHelpMessage(
     int status,
-    const boost::program_options::options_description &options_description) {
+    const boost::program_options::options_description& options_description) {
   (status == 0 ? std::cout : std::cerr) << options_description << std::endl;
   std::exit(status);
 }
 
 ClusteringObjective DetermineObjectiveFunction(
-    const std::string &objective_name) {
+    const std::string& objective_name) {
   if (objective_name == "ratio_cut") {
     return kRatioCut;
   } else if (objective_name == "ratio_association") {
@@ -103,7 +103,7 @@ int main(int argc, const char **argv) {
         opts::parse_command_line(argc, argv, options_description),
         clustering_options);
     opts::notify(clustering_options);
-  } catch (const std::exception &e) {
+  } catch (const std::exception& e) {
     std::cerr << e.what() << std::endl;
     ExitWithHelpMessage(-1, options_description);
   }
@@ -141,7 +141,7 @@ int main(int argc, const char **argv) {
     } else {
       cannot_links = CannotLinks(boost::num_vertices(graph));
     }
-  } catch (const std::exception &e) {
+  } catch (const std::exception& e) {
     std::cerr << e.what() << std::endl;
     return -1;
   }
@@ -161,7 +161,7 @@ int main(int argc, const char **argv) {
     for (const auto cluster_id: cluster_numbers) {
       std::cout << cluster_id << std::endl;
     }
-  } catch (const std::exception &e) {
+  } catch (const std::exception& e) {
     std::cerr << e.what() << std::endl;
     return -1;
   }

--- a/sample/graph_clustering.cc
+++ b/sample/graph_clustering.cc
@@ -37,11 +37,11 @@ void ExitWithHelpMessage(
 ClusteringObjective DetermineObjectiveFunction(
     const std::string& objective_name) {
   if (objective_name == "ratio_cut") {
-    return kRatioCut;
+    return ClusteringObjective::RatioCut;
   } else if (objective_name == "ratio_association") {
-    return kRatioAssociation;
+    return ClusteringObjective::RatioAssociation;
   } else if (objective_name == "normalized_cut") {
-    return kNormalizedCut;
+    return ClusteringObjective::NormalizedCut;
   } else {
     throw std::invalid_argument(
         "Not supported objective function: " + objective_name);

--- a/sample/graph_clustering.cc
+++ b/sample/graph_clustering.cc
@@ -158,7 +158,7 @@ int main(int argc, const char **argv) {
         cluster_numbers[iter.row()] = iter.col();
       }
     }
-    for (const auto cluster_id: cluster_numbers) {
+    for (const auto cluster_id : cluster_numbers) {
       std::cout << cluster_id << std::endl;
     }
   } catch (const std::exception& e) {

--- a/sample/kernel_k_means.cc
+++ b/sample/kernel_k_means.cc
@@ -25,7 +25,7 @@ namespace {
 
 template <typename Matrix>
 KernelMatrix ComputeKernelMatrix(
-    const Matrix &vectors, const std::vector<std::string> &kernel_parameters) {
+    const Matrix& vectors, const std::vector<std::string>& kernel_parameters) {
   if (kernel_parameters.size() == 0) {
     throw std::invalid_argument("No kernel parameters are given.");
   }
@@ -62,7 +62,7 @@ KernelMatrix ComputeKernelMatrix(
 
 void ExitWithHelpMessage(
     int status,
-    const boost::program_options::options_description &options_description) {
+    const boost::program_options::options_description& options_description) {
   (status == 0 ? std::cout : std::cerr) << options_description << std::endl;
   std::exit(status);
 }
@@ -98,7 +98,7 @@ ClusterIndicatorMatrix InitializeRandomClusters(
 }
 
 std::vector<std::string> SplitString(
-    const std::string &original_string, const std::string &separator) {
+    const std::string& original_string, const std::string& separator) {
   std::vector<std::string> separated_strings;
   std::size_t offset = 0;
   for (std::size_t found_position = original_string.find(separator, offset);
@@ -159,7 +159,7 @@ int main(int argc, const char **argv) {
         opts::parse_command_line(argc, argv, options_description),
         clustering_options);
     opts::notify(clustering_options);
-  } catch (const std::exception &e) {
+  } catch (const std::exception& e) {
     std::cerr << e.what() << std::endl;
     ExitWithHelpMessage(-1, options_description);
   }
@@ -198,7 +198,7 @@ int main(int argc, const char **argv) {
         throw std::invalid_argument("Input matrix is invalid.");
       }
     }
-  } catch (const std::exception &e) {
+  } catch (const std::exception& e) {
     std::cerr << e.what() << std::endl;
     ExitWithHelpMessage(-1, options_description);
   }
@@ -211,7 +211,7 @@ int main(int argc, const char **argv) {
   ConvergencePredicator converged(500, 20, 0.001);
   try {
     clusters = ExecuteKernelKMeans(clusters, k_min, kernels, converged);
-  } catch (const TooFewClustersLeft &) {
+  } catch (const TooFewClustersLeft&) {
     std::cerr << "Number of clusters became less than wanted." << std::endl;
     return 1;
   }

--- a/sample/kernel_k_means.cc
+++ b/sample/kernel_k_means.cc
@@ -177,7 +177,7 @@ int main(int argc, const char **argv) {
   ClusterIndicatorMatrix clusters;
   try {
     switch (DetermineMatrixType(cluto_matrix)) {
-      case kDenseMatrix: {
+      case MatrixType::DenseMatrix: {
         /*
           Usually, vector data are serialized as *row* vectors. So we need to
           transpose it by setting on |transpose| flag as optional 2nd argument.
@@ -187,7 +187,7 @@ int main(int argc, const char **argv) {
         clusters = InitializeRandomClusters(dense_vectors.cols(), k);
         break;
       }
-      case kSparseMatrix: {
+      case MatrixType::SparseMatrix: {
         // Ditto.
         SparseMatrix sparse_vectors = ParseSparseMatrix(cluto_matrix, true);
         kernels = ComputeKernelMatrix(sparse_vectors, kernel_parameters);

--- a/sample/kernel_k_means.cc
+++ b/sample/kernel_k_means.cc
@@ -82,7 +82,7 @@ ClusterIndicatorMatrix InitializeRandomClusters(
       coeffs[i] = SparseMatrixCoefficient(i, cluster_index, 1.0);
       ++cluster_sizes[cluster_index];
     }
-    for (const auto cluster_size: cluster_sizes) {
+    for (const auto cluster_size : cluster_sizes) {
       if (cluster_size == 0) { goto CONTINUE_OUTER_LOOP; }
     }
     break;
@@ -226,7 +226,7 @@ int main(int argc, const char **argv) {
       cluster_numbers[iter.row()] = iter.col();
     }
   }
-  for (const auto cluster_id: cluster_numbers) {
+  for (const auto cluster_id : cluster_numbers) {
     std::cout << cluster_id << std::endl;
   }
 

--- a/sample/kernel_k_means.cc
+++ b/sample/kernel_k_means.cc
@@ -1,4 +1,3 @@
-#include <boost/foreach.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/parsers.hpp>
@@ -84,7 +83,7 @@ ClusterIndicatorMatrix InitializeRandomClusters(
       coeffs[i] = SparseMatrixCoefficient(i, cluster_index, 1.0);
       ++cluster_sizes[cluster_index];
     }
-    BOOST_FOREACH (const int cluster_size, cluster_sizes) {
+    for (const auto cluster_size: cluster_sizes) {
       if (cluster_size == 0) { goto CONTINUE_OUTER_LOOP; }
     }
     break;
@@ -228,8 +227,7 @@ int main(int argc, const char **argv) {
       cluster_numbers[iter.row()] = iter.col();
     }
   }
-  BOOST_FOREACH (
-      const ClusterIndicatorMatrix::Index cluster_id, cluster_numbers) {
+  for (const auto cluster_id: cluster_numbers) {
     std::cout << cluster_id << std::endl;
   }
 

--- a/sample/kernel_k_means.cc
+++ b/sample/kernel_k_means.cc
@@ -3,11 +3,10 @@
 #include <boost/program_options/parsers.hpp>
 #include <boost/program_options/value_semantic.hpp>
 #include <boost/program_options/variables_map.hpp>
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/random/uniform_int_distribution.hpp>
 #include <cstdlib>
 #include <exception>
 #include <iostream>
+#include <random>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -67,13 +66,13 @@ void ExitWithHelpMessage(
   std::exit(status);
 }
 
-boost::random::mt19937 rng_;
+std::mt19937 rng_;
 
 // TODO(sekia): Move to library.
 ClusterIndicatorMatrix InitializeRandomClusters(
     ClusterIndicatorMatrix::Index num_vectors,
     ClusterIndicatorMatrix::Index num_clusters) {
-  boost::random::uniform_int_distribution<> dist(0, num_clusters - 1);
+  std::uniform_int_distribution<> dist(0, num_clusters - 1);
 
   std::vector<SparseMatrixCoefficient> coeffs(num_vectors);
   std::vector<int> cluster_sizes(num_clusters);

--- a/test/cluto_matrix_test.cc
+++ b/test/cluto_matrix_test.cc
@@ -13,21 +13,21 @@ TEST(ClutoMatrixTest, CanDetermineMatrixType) {
       "1 1 2\n"
       "3 5 8\n"
       "13 21 34\n";
-  EXPECT_EQ(kInvalidMatrix, DetermineMatrixType(invalid_header));
+  EXPECT_EQ(MatrixType::InvalidMatrix, DetermineMatrixType(invalid_header));
 
   std::string dense_matrix =
       "3 3\n"
       "1 1 2\n"
       "3 5 8\n"
       "13 21 34\n";
-  EXPECT_EQ(kDenseMatrix, DetermineMatrixType(dense_matrix));
+  EXPECT_EQ(MatrixType::DenseMatrix, DetermineMatrixType(dense_matrix));
 
   std::string sparse_matrix =
       "3 10 9\n"
       "1 1.0 3 1.0 5 1.0\n"
       "4 3.0 7 2.0 10 1.0\n"
       "2 2.0 4 4.0 6 6.0\n";
-  EXPECT_EQ(kSparseMatrix, DetermineMatrixType(sparse_matrix));
+  EXPECT_EQ(MatrixType::SparseMatrix, DetermineMatrixType(sparse_matrix));
 }
 
 TEST(ClutoMatrixTest, CanParseDenseMatrix) {

--- a/test/kernel_k_means_test.cc
+++ b/test/kernel_k_means_test.cc
@@ -1,6 +1,3 @@
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/random/uniform_int_distribution.hpp>
-#include <boost/random/uniform_real_distribution.hpp>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -58,9 +55,7 @@ TEST(KernelKMeansTest, WeightedKkmIsSameAsKkmWhenWeightsAreOnes) {
 }
 
 TEST(KernelKMeansTest, TwoImplementationsOfWeightedKkmMakeIdenticalResults) {
-  boost::random::mt19937 rng;
   for (int i = 10; i < 20; ++i) {
-    boost::random::uniform_int_distribution<> cluster_selector(0, i - 1);
     DenseMatrix vectors = DenseMatrix::Random(3, 500);
     KernelMatrix kernels = ComputePolynomialKernelMatrix(vectors, 0, 2);
     WeightVector weights = WeightVector::Random(vectors.cols());

--- a/test/kernel_k_means_test.cc
+++ b/test/kernel_k_means_test.cc
@@ -22,8 +22,8 @@ class Counter {
   void Reset() { current_count_ = 0; }
 
  private:
-  Counter(const Counter &);
-  Counter &operator=(const Counter &);
+  Counter(const Counter&);
+  Counter& operator=(const Counter&);
   int count_;
   int current_count_;
 };

--- a/test/test_util.h
+++ b/test/test_util.h
@@ -1,8 +1,7 @@
 #ifndef TEST_TEST_UTIL_H_
 #define TEST_TEST_UTIL_H_
 
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/random/uniform_int_distribution.hpp>
+#include <random>
 #include <vector>
 #include <Eigen/Sparse>
 
@@ -27,8 +26,8 @@ inline bool operator==(
 
 inline ClusterIndicatorMatrix InitializeRandomClusters(
     unsigned num_vectors, unsigned num_clusters) {
-  static boost::random::mt19937 rng;
-  boost::random::uniform_int_distribution<> dist(0, num_clusters - 1);
+  static std::mt19937 rng;
+  std::uniform_int_distribution<> dist(0, num_clusters - 1);
   std::vector<SparseMatrixCoefficient> cluster_indicators;
   cluster_indicators.reserve(num_vectors);
   while (true) {

--- a/test/test_util.h
+++ b/test/test_util.h
@@ -9,7 +9,7 @@
 namespace sskkm {
 
 inline bool operator==(
-    const SparseMatrix &matrix1, const SparseMatrix &matrix2) {
+    const SparseMatrix& matrix1, const SparseMatrix& matrix2) {
   if (matrix1.rows() != matrix2.rows() || matrix1.cols() != matrix2.cols()) {
     return false;
   }


### PR DESCRIPTION
Use C++11 features such as range-based for, scoped enum and newly added standard libraries for readability and portability.
Of course I'm sure nowadays C++14 is widely available though, a compiler I'm using for development is GCC 4.8, which supports the language revision only partially :(
